### PR TITLE
Remove stdClass support, and validate required fields.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Tweet Entity Linker
 [![Packagist](https://img.shields.io/packagist/v/jedkirby/tweet-entity-linker.svg?style=flat-square)](https://packagist.org/packages/jedkirby/tweet-entity-linker)
 [![Packagist](https://img.shields.io/packagist/l/jedkirby/tweet-entity-linker.svg?style=flat-square)](https://github.com/jedkirby/tweet-entity-linker/blob/master/LICENSE)
 
-Description Required.
+Tweet Entity Linker is a very simple package and requires minimal setup. It's designed to simply _only_ convert a tweets text, along with it's entities, to a HTML rich string enabling linking of URLs, User Mentions and Hashtags.
 
 Installation
 -------
@@ -18,6 +18,102 @@ $ composer require jedkirby/tweet-entity-linker
 ```
 
 It requires **PHP >= 5.6.4**.
+
+Usage
+-------
+
+The following guide assumes that you've imported the class `Jedkirby\TweetEntityLinker\Tweet` into your namespace.
+
+The `Tweet` class requires that you pass it parameters so it's able to create the linkified text. Generally these parameters will be the responses from Twitter API endpoints, like [statuses/show/:id](https://dev.twitter.com/rest/reference/get/statuses/show/id), however, it's not required.
+
+The following pseudo code should help explain what's needed when using the response from the API (Please see the [example response](https://dev.twitter.com/rest/reference/get/statuses/show/id#example-response)):
+
+``` php
+$request = Api::get('https://api.twitter.com/1.1/statuses/show/123456');
+
+$tweet = new Tweet(
+  $request['text'],
+  $request['entities']['urls'],
+  $request['entities']['user_mentions'],
+  $request['entities']['hashtags']
+);
+```
+
+Now the `Tweet` class has been populated with the parameters it needs, you can call the `linkify()` method to return the text with URLs, User Mentions and Hashtags converted to their HTML entities:
+
+``` php
+$text = $tweet->linkify();
+```
+
+### Manually Creating Parameters
+
+You're able to create the parametes manually, however, they require some specific properties in order for the `linkify()` method to function correctly, these are as follows:
+
+#### Parameter 1: Text
+
+This field is _always_ required, and if containing either a URL, User Mention or Hashtag, the corresponding parameter array's should be populated. The following example assumes we have all of those:
+
+``` php
+$text = 'This notifies @jedkirby, with the hashtag #Awesome, and the URL https://t.co/Ed4omjYz.';
+```
+
+#### Parameter 2: URLs
+
+The URLs parameter is an array of array's, of which it must contain the `url` and `display_url` fields:
+
+``` php
+$urls = [
+  [
+    'url'         => 'https://t.co/Ed4omjYz',
+    'display_url' => 'https://jedkirby.com'
+  ]
+];
+```
+
+#### Parameter 3: User Mentions
+
+The User Mentions parameter is an array of array's, of which it must contain only a `screen_name` field:
+
+``` php
+$mentions = [
+  [
+    'screen_name' => 'jedkirby'
+  ]
+];
+```
+
+#### Parameter 4: Hashtags
+
+The Hashtags parameter is an array of array's, of which it must contain only a `text` field:
+
+``` php
+$hashtags = [
+  [
+    'text' => 'Awesome'
+  ]
+];
+```
+
+#### Result
+
+When putting all the above parameters together, you'd get the following:
+
+``` php
+$tweet = new Tweet(
+  $text,
+  $urls,
+  $mentions,
+  $hashtags
+);
+
+var_dump($tweet->linkify());
+```
+
+With the response being:
+
+``` none
+string(262) "This notifies @<a href="https://twitter.com/jedkirby" target="_blank">jedkirby</a>, with the hashtag #<a href="https://twitter.com/hashtag/Awesome" target="_blank">Awesome</a>, and the URL <a href="https://t.co/Ed4omjYz" target="_blank">https://jedkirby.com</a>."
+```
 
 Testing
 -------

--- a/src/Entity/AbstractEntity.php
+++ b/src/Entity/AbstractEntity.php
@@ -2,39 +2,46 @@
 
 namespace Jedkirby\TweetEntityLinker\Entity;
 
+use Jedkirby\TweetEntityLinker\Entity\Exception\RequiredPropertyException;
+
 abstract class AbstractEntity implements EntityInterface
 {
 
     /**
-     * @var stdClass
+     * @var array
      */
-    private $data;
+    protected $data = [];
 
     /**
-     * @param stdClass $data
+     * @param array $data
      */
-    public function __construct($data)
+    public function __construct(array $data = [])
     {
         $this->data = $data;
+        $this->validate();
     }
 
     /**
-     * Return a data item whether it's within an array or an object.
-     *
-     * @param string $key
-     * @param mixed $default
-     *
-     * @return mixed
+     * @throws RequiredPropertyException
+     * @return void
      */
-    protected function getDataItem($key, $default = '')
+    private function validate()
     {
-        if (is_object($this->data)) {
-            return $this->data->$key;
-        } elseif (is_array($this->data)) {
-            return $this->data[$key];
-        } else {
-            return $default;
+
+        $requiredProperties = $this->getRequiredProperties();
+        $missingProperties = array_diff(
+            $requiredProperties,
+            array_keys($this->data)
+        );
+
+        if ($missingProperties) {
+            throw new RequiredPropertyException(sprintf(
+                'The following properties "%s" are required for the entity "%s".',
+                implode(', ', $requiredProperties),
+                get_called_class()
+            ));
         }
+
     }
 
 }

--- a/src/Entity/EntityInterface.php
+++ b/src/Entity/EntityInterface.php
@@ -6,6 +6,13 @@ interface EntityInterface
 {
 
     /**
+     * Return properties to validate on loading of the entity.
+     *
+     * @return array
+     */
+    public function getRequiredProperties();
+
+    /**
      * Return the text to search for.
      *
      * @return string

--- a/src/Entity/Exception/RequiredPropertyException.php
+++ b/src/Entity/Exception/RequiredPropertyException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Jedkirby\TweetEntityLinker\Entity\Exception;
+
+use Exception;
+
+class RequiredPropertyException extends Exception
+{
+
+}

--- a/src/Entity/Hashtag.php
+++ b/src/Entity/Hashtag.php
@@ -8,9 +8,17 @@ class Hashtag extends AbstractEntity
     /**
      * {@inhertDoc}
      */
+    public function getRequiredProperties()
+    {
+        return ['text'];
+    }
+
+    /**
+     * {@inhertDoc}
+     */
     public function getSearchText()
     {
-        return $this->getDataItem('text');
+        return $this->data['text'];
     }
 
     /**
@@ -20,8 +28,8 @@ class Hashtag extends AbstractEntity
     {
         return sprintf(
             '<a href="https://twitter.com/hashtag/%s" target="_blank">%s</a>',
-            $this->getDataItem('text'),
-            $this->getDataItem('text')
+            $this->data['text'],
+            $this->data['text']
         );
     }
 

--- a/src/Entity/Url.php
+++ b/src/Entity/Url.php
@@ -8,9 +8,17 @@ class Url extends AbstractEntity
     /**
      * {@inhertDoc}
      */
+    public function getRequiredProperties()
+    {
+        return ['url', 'display_url'];
+    }
+
+    /**
+     * {@inhertDoc}
+     */
     public function getSearchText()
     {
-        return $this->getDataItem('url');
+        return $this->data['url'];
     }
 
     /**
@@ -20,8 +28,8 @@ class Url extends AbstractEntity
     {
         return sprintf(
             '<a href="%s" target="_blank">%s</a>',
-            $this->getDataItem('url'),
-            $this->getDataItem('display_url')
+            $this->data['url'],
+            $this->data['display_url']
         );
     }
 

--- a/src/Entity/UserMention.php
+++ b/src/Entity/UserMention.php
@@ -8,9 +8,17 @@ class UserMention extends AbstractEntity
     /**
      * {@inhertDoc}
      */
+    public function getRequiredProperties()
+    {
+        return ['screen_name'];
+    }
+
+    /**
+     * {@inhertDoc}
+     */
     public function getSearchText()
     {
-        return $this->getDataItem('screen_name');
+        return $this->data['screen_name'];
     }
 
     /**
@@ -20,8 +28,8 @@ class UserMention extends AbstractEntity
     {
         return sprintf(
             '<a href="https://twitter.com/%s" target="_blank">%s</a>',
-            $this->getDataItem('screen_name'),
-            $this->getDataItem('screen_name')
+            $this->data['screen_name'],
+            $this->data['screen_name']
         );
     }
 

--- a/tests/Entity/EntityTest.php
+++ b/tests/Entity/EntityTest.php
@@ -2,27 +2,28 @@
 
 namespace Tests\Jedkirby\TweetEntityLinker\Entity;
 
-use Jedkirby\TweetEntityLinker\Tweet;
 use PHPUnit_Framework_TestCase as TestCase;
-use Tests\Jedkirby\TweetEntityLinker\Entity\Fixtures\Sample;
+use Tests\Jedkirby\TweetEntityLinker\Entity\Fixtures\InvalidProperties;
+use Tests\Jedkirby\TweetEntityLinker\Entity\Fixtures\NoRequiredProperties;
 
 class EntityTest extends TestCase
 {
 
     /**
      * @test
+     * @expectedException Jedkirby\TweetEntityLinker\Entity\Exception\RequiredPropertyException
      */
-    public function itUsesTheDefaultValueWhenGettingDataItem()
+    public function itMustHaveRequiredProperties()
     {
-
-        $entity = new Sample(false);
-
-        $this->assertEquals(
-            $entity->getSearchText(),
-            'default'
-        );
-
+        $entity = new InvalidProperties();
     }
 
+    /**
+     * @test
+     */
+    public function itDoesNotNeedToHaveRequiredProperties()
+    {
+        $entity = new NoRequiredProperties();
+    }
 
 }

--- a/tests/Entity/Fixtures/InvalidProperties.php
+++ b/tests/Entity/Fixtures/InvalidProperties.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Jedkirby\TweetEntityLinker\Entity\Fixtures;
+
+use Jedkirby\TweetEntityLinker\Entity\AbstractEntity;
+
+class InvalidProperties extends AbstractEntity
+{
+
+    /**
+     * {@inhertDoc}
+     */
+    public function getRequiredProperties()
+    {
+        return ['missing', 'required'];
+    }
+
+    /**
+     * {@inhertDoc}
+     */
+    public function getSearchText()
+    {
+        return '';
+    }
+
+    /**
+     * {@inhertDoc}
+     */
+    public function getHtml()
+    {
+        return '';
+    }
+
+}

--- a/tests/Entity/Fixtures/NoRequiredProperties.php
+++ b/tests/Entity/Fixtures/NoRequiredProperties.php
@@ -4,15 +4,23 @@ namespace Tests\Jedkirby\TweetEntityLinker\Entity\Fixtures;
 
 use Jedkirby\TweetEntityLinker\Entity\AbstractEntity;
 
-class Sample extends AbstractEntity
+class NoRequiredProperties extends AbstractEntity
 {
+
+    /**
+     * {@inhertDoc}
+     */
+    public function getRequiredProperties()
+    {
+        return [];
+    }
 
     /**
      * {@inhertDoc}
      */
     public function getSearchText()
     {
-        return $this->getDataItem('key', 'default');
+        return '';
     }
 
     /**

--- a/tests/TweetTest.php
+++ b/tests/TweetTest.php
@@ -10,11 +10,10 @@ class TweetTest extends TestCase
 
     /**
      * @param string $endpoint
-     * @param boolean $assoc
      *
-     * @return stdClass|array
+     * @return array
      */
-    protected function getSampleApiResponse($endpoint, $assoc = false)
+    protected function getSampleApiResponse($endpoint)
     {
         return json_decode(
             file_get_contents(
@@ -23,7 +22,7 @@ class TweetTest extends TestCase
                     $endpoint
                 )
             ),
-            $assoc
+            true
         );
     }
 
@@ -31,20 +30,19 @@ class TweetTest extends TestCase
      * Create a new Tweet object from a sample API response.
      *
      * @param string $endpoint
-     * @param boolean $assoc
      *
      * @return Tweet
      */
-    protected function getSampleTweet($endpoint, $assoc = false)
+    protected function getSampleTweet($endpoint)
     {
 
-        $response = $this->getSampleApiResponse($endpoint, $assoc);
+        $response = $this->getSampleApiResponse($endpoint);
 
         return Tweet::make(
-            $response->text,
-            $response->entities->urls,
-            $response->entities->user_mentions,
-            $response->entities->hashtags
+            $response['text'],
+            $response['entities']['urls'],
+            $response['entities']['user_mentions'],
+            $response['entities']['hashtags']
         );
 
     }
@@ -83,54 +81,14 @@ class TweetTest extends TestCase
     }
 
     /**
-     * @return string
-     */
-    protected function getAllEntitiesCorrectString()
-    {
-        return 'This tweet has it all, it has got the links <a href="https://t.co/qeSnkprYiP" target="_blank">jedkirby.com</a> and <a href="https://t.co/Ed4omjYs" target="_blank">google.co.uk</a>, it has the hashtags #<a href="https://twitter.com/hashtag/Hashtag" target="_blank">Hashtag</a> and #<a href="https://twitter.com/hashtag/Another" target="_blank">Another</a>, and finally the user mentions for @<a href="https://twitter.com/jedkirby" target="_blank">jedkirby</a> and @<a href="https://twitter.com/google" target="_blank">google</a>.';
-    }
-
-    /**
      * @test
      */
     public function itParsesAllEntitiesCorrectly()
     {
         $this->assertEquals(
             $this->getSampleTweet('all-entities')->linkify(),
-            $this->getAllEntitiesCorrectString()
+            'This tweet has it all, it has got the links <a href="https://t.co/qeSnkprYiP" target="_blank">jedkirby.com</a> and <a href="https://t.co/Ed4omjYs" target="_blank">google.co.uk</a>, it has the hashtags #<a href="https://twitter.com/hashtag/Hashtag" target="_blank">Hashtag</a> and #<a href="https://twitter.com/hashtag/Another" target="_blank">Another</a>, and finally the user mentions for @<a href="https://twitter.com/jedkirby" target="_blank">jedkirby</a> and @<a href="https://twitter.com/google" target="_blank">google</a>.'
         );
-    }
-
-    /**
-     * @test
-     */
-    public function itHandlesObjectEntities()
-    {
-        $this->assertEquals(
-            $this->getSampleTweet('all-entities', false)->linkify(),
-            $this->getAllEntitiesCorrectString()
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function itHandlesArrayEntities()
-    {
-
-        $response = $this->getSampleApiResponse('all-entities', true);
-        $tweet = Tweet::make(
-            $response['text'],
-            $response['entities']['urls'],
-            $response['entities']['user_mentions'],
-            $response['entities']['hashtags']
-        );
-
-        $this->assertEquals(
-            $tweet->linkify(),
-            $this->getAllEntitiesCorrectString()
-        );
-
     }
 
 }


### PR DESCRIPTION
Continuing support for `array`'s and `stdClass`es adds unnecessary complexity to the _simple_ package, so I'm removing that.

I've added in required field checking into each of the entities to give useful information should an entities data have the incorrect properties.

I've also populated the read me file with the first iteration of a "guide".

Test's have been updated to reflect these changes,