### PR TITLE
Using composers autoloader

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__ . '/vendor/jedkirby/php-cs/src/Config.php';
+require_once realpath(__DIR__ . '/vendor/autoload.php');
 
 use PhpCsFixer\Finder;
 use Jedkirby\PhpCs\Config;


### PR DESCRIPTION
The PHP CS implementation can load up composer instead of `require_once`ing the class it needs directly, this'll account for any changes in the package automatically.