### PR TITLE
Entity Keys & Single Replacements

### DIFF
--- a/src/Entity/AbstractEntity.php
+++ b/src/Entity/AbstractEntity.php
@@ -21,6 +21,14 @@ abstract class AbstractEntity implements EntityInterface
     }
 
     /**
+     * {@inhertdoc}.
+     */
+    public function getSearchPattern()
+    {
+        return '/' . preg_quote($this->getSearchText(), '/') . '/';
+    }
+
+    /**
      * @throws RequiredPropertyException
      */
     private function validate()

--- a/src/Entity/EntityInterface.php
+++ b/src/Entity/EntityInterface.php
@@ -22,6 +22,13 @@ interface EntityInterface
     public function getSearchText();
 
     /**
+     * Return a pattern to be used by a regular expression for a search.
+     *
+     * @return string
+     */
+    public function getSearchPattern();
+
+    /**
      * Return the text to replace.
      *
      * @return string

--- a/src/Entity/Hashtag.php
+++ b/src/Entity/Hashtag.php
@@ -5,6 +5,14 @@ namespace Jedkirby\TweetEntityLinker\Entity;
 class Hashtag extends AbstractEntity
 {
     /**
+     * @return string
+     */
+    private function getEntityKey()
+    {
+        return '#';
+    }
+
+    /**
      * {@inhertDoc}.
      */
     public function getRequiredProperties()
@@ -17,7 +25,7 @@ class Hashtag extends AbstractEntity
      */
     public function getSearchText()
     {
-        return $this->data['text'];
+        return $this->getEntityKey() . $this->data['text'];
     }
 
     /**
@@ -26,7 +34,8 @@ class Hashtag extends AbstractEntity
     public function getHtml()
     {
         return sprintf(
-            '<a href="https://twitter.com/hashtag/%s" target="_blank">%s</a>',
+            '%s<a href="https://twitter.com/hashtag/%s" target="_blank">%s</a>',
+            $this->getEntityKey(),
             $this->data['text'],
             $this->data['text']
         );

--- a/src/Entity/Hashtag.php
+++ b/src/Entity/Hashtag.php
@@ -5,12 +5,9 @@ namespace Jedkirby\TweetEntityLinker\Entity;
 class Hashtag extends AbstractEntity
 {
     /**
-     * @return string
+     * @var string
      */
-    private function getEntityKey()
-    {
-        return '#';
-    }
+    const ENTITY_KEY = '#';
 
     /**
      * {@inhertdoc}.
@@ -25,7 +22,7 @@ class Hashtag extends AbstractEntity
      */
     public function getSearchText()
     {
-        return $this->getEntityKey() . $this->data['text'];
+        return self::ENTITY_KEY . $this->data['text'];
     }
 
     /**
@@ -35,7 +32,7 @@ class Hashtag extends AbstractEntity
     {
         return sprintf(
             '%s<a href="https://twitter.com/hashtag/%s" target="_blank">%s</a>',
-            $this->getEntityKey(),
+            self::ENTITY_KEY,
             $this->data['text'],
             $this->data['text']
         );

--- a/src/Entity/Hashtag.php
+++ b/src/Entity/Hashtag.php
@@ -13,7 +13,7 @@ class Hashtag extends AbstractEntity
     }
 
     /**
-     * {@inhertDoc}.
+     * {@inhertdoc}.
      */
     public function getRequiredProperties()
     {
@@ -21,7 +21,7 @@ class Hashtag extends AbstractEntity
     }
 
     /**
-     * {@inhertDoc}.
+     * {@inhertdoc}.
      */
     public function getSearchText()
     {
@@ -29,7 +29,7 @@ class Hashtag extends AbstractEntity
     }
 
     /**
-     * {@inhertDoc}.
+     * {@inhertdoc}.
      */
     public function getHtml()
     {

--- a/src/Entity/Url.php
+++ b/src/Entity/Url.php
@@ -5,7 +5,7 @@ namespace Jedkirby\TweetEntityLinker\Entity;
 class Url extends AbstractEntity
 {
     /**
-     * {@inhertDoc}.
+     * {@inhertdoc}.
      */
     public function getRequiredProperties()
     {
@@ -13,7 +13,7 @@ class Url extends AbstractEntity
     }
 
     /**
-     * {@inhertDoc}.
+     * {@inhertdoc}.
      */
     public function getSearchText()
     {
@@ -21,7 +21,7 @@ class Url extends AbstractEntity
     }
 
     /**
-     * {@inhertDoc}.
+     * {@inhertdoc}.
      */
     public function getHtml()
     {

--- a/src/Entity/UserMention.php
+++ b/src/Entity/UserMention.php
@@ -5,12 +5,9 @@ namespace Jedkirby\TweetEntityLinker\Entity;
 class UserMention extends AbstractEntity
 {
     /**
-     * @return string
+     * @var string
      */
-    private function getEntityKey()
-    {
-        return '@';
-    }
+    const ENTITY_KEY = '@';
 
     /**
      * {@inhertdoc}.
@@ -25,7 +22,7 @@ class UserMention extends AbstractEntity
      */
     public function getSearchText()
     {
-        return $this->getEntityKey() . $this->data['screen_name'];
+        return self::ENTITY_KEY . $this->data['screen_name'];
     }
 
     /**
@@ -35,7 +32,7 @@ class UserMention extends AbstractEntity
     {
         return sprintf(
             '%s<a href="https://twitter.com/%s" target="_blank">%s</a>',
-            $this->getEntityKey(),
+            self::ENTITY_KEY,
             $this->data['screen_name'],
             $this->data['screen_name']
         );

--- a/src/Entity/UserMention.php
+++ b/src/Entity/UserMention.php
@@ -13,7 +13,7 @@ class UserMention extends AbstractEntity
     }
 
     /**
-     * {@inhertDoc}.
+     * {@inhertdoc}.
      */
     public function getRequiredProperties()
     {
@@ -21,7 +21,7 @@ class UserMention extends AbstractEntity
     }
 
     /**
-     * {@inhertDoc}.
+     * {@inhertdoc}.
      */
     public function getSearchText()
     {
@@ -29,7 +29,7 @@ class UserMention extends AbstractEntity
     }
 
     /**
-     * {@inhertDoc}.
+     * {@inhertdoc}.
      */
     public function getHtml()
     {

--- a/src/Entity/UserMention.php
+++ b/src/Entity/UserMention.php
@@ -5,6 +5,14 @@ namespace Jedkirby\TweetEntityLinker\Entity;
 class UserMention extends AbstractEntity
 {
     /**
+     * @return string
+     */
+    private function getEntityKey()
+    {
+        return '@';
+    }
+
+    /**
      * {@inhertDoc}.
      */
     public function getRequiredProperties()
@@ -17,7 +25,7 @@ class UserMention extends AbstractEntity
      */
     public function getSearchText()
     {
-        return $this->data['screen_name'];
+        return $this->getEntityKey() . $this->data['screen_name'];
     }
 
     /**
@@ -26,7 +34,8 @@ class UserMention extends AbstractEntity
     public function getHtml()
     {
         return sprintf(
-            '<a href="https://twitter.com/%s" target="_blank">%s</a>',
+            '%s<a href="https://twitter.com/%s" target="_blank">%s</a>',
+            $this->getEntityKey(),
             $this->data['screen_name'],
             $this->data['screen_name']
         );

--- a/src/Tweet.php
+++ b/src/Tweet.php
@@ -74,10 +74,11 @@ class Tweet
 
         $text = $this->text;
         foreach ($entities as $entity) {
-            $text = str_replace(
-                $entity->getSearchText(),
+            $text = preg_replace(
+                $entity->getSearchPattern(),
                 $entity->getHtml(),
-                $text
+                $text,
+                1
             );
         }
 

--- a/tests/Fixtures/hashtag-and-user-mention-duplicate-entity.json
+++ b/tests/Fixtures/hashtag-and-user-mention-duplicate-entity.json
@@ -1,0 +1,27 @@
+{
+    "text": "This tweet hashtags #jedkirby and also mentions @jedkirby",
+    "entities": {
+        "urls": [],
+        "hashtags": [
+            {
+                "text": "jedkirby",
+                "indices": [
+                    0,
+                    0
+                ]
+            }
+        ],
+        "user_mentions": [
+            {
+                "screen_name": "jedkirby",
+                "name": "James Kirby",
+                "id": 12345,
+                "id_str": "12345",
+                "indices": [
+                    0,
+                    0
+                ]
+            }
+        ]
+    }
+}

--- a/tests/TweetTest.php
+++ b/tests/TweetTest.php
@@ -87,4 +87,15 @@ class TweetTest extends TestCase
             'This tweet has it all, it has got the links <a href="https://t.co/qeSnkprYiP" target="_blank">jedkirby.com</a> and <a href="https://t.co/Ed4omjYs" target="_blank">google.co.uk</a>, it has the hashtags #<a href="https://twitter.com/hashtag/Hashtag" target="_blank">Hashtag</a> and #<a href="https://twitter.com/hashtag/Another" target="_blank">Another</a>, and finally the user mentions for @<a href="https://twitter.com/jedkirby" target="_blank">jedkirby</a> and @<a href="https://twitter.com/google" target="_blank">google</a>.'
         );
     }
+
+    /**
+     * @test
+     */
+    public function itParsesDuplicateHashtagAndUserMentionCorrectly()
+    {
+        $this->assertEquals(
+            $this->getSampleTweet('hashtag-and-user-mention-duplicate-entity')->linkify(),
+            'This tweet hashtags #<a href="https://twitter.com/hashtag/jedkirby" target="_blank">jedkirby</a> and also mentions @<a href="https://twitter.com/jedkirby" target="_blank">jedkirby</a>'
+        );
+    }
 }


### PR DESCRIPTION
## Entity Keys
By not using entity keys (i.e. `#` or `@`) within replacement searches, it meant that tweet text which contained identical hashtag and user mention text would incorrectly replace, i.e:

``` php
$text = 'This is for #jedkirby and mentions @jedkirby';
```

Previously the above would match, for example the hashtag entity, `jedkirby` and do the replacement which would replace both the hashtag and the user mention.

Searching now uses the entity key, so the new search parameter would be `#jedkirby` which would only replace the correct entity.

## Single Replacements
Previously the replacement method was done using the `str_replace` function, however, there's no easy or nice way of ensuring that this function only replaces a single entity.

I've migrated this to use the `preg_replace` function, as this allows for a replacement limit, and added an interface method, `getSearchPattern()`, for returning a regular expression pattern for the entity.

I realise that `preg_replace` is slower than `str_replace`, however, this functionality needs to be present.