### PR TITLE
Add support for $Cashtags

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ $tweet = Tweet::make(
   $request['text'],
   $request['entities']['urls'],
   $request['entities']['user_mentions'],
-  $request['entities']['hashtags']
+  $request['entities']['hashtags'],
+  $request['entities']['cashtags']
 );
 ```
 
@@ -95,6 +96,18 @@ $hashtags = [
 ];
 ```
 
+#### Parameter 5: Cashtags
+
+The Hashtags parameter is an array of array's, of which it must contain only a `text` field:
+
+```php
+$cashtags = [
+  [
+    'text' => 'AAPL'  
+  ]
+];
+```
+
 #### Result
 
 When putting all the above parameters together, you'd get the following:
@@ -104,7 +117,8 @@ $tweet = Tweet::make(
   $text,
   $urls,
   $mentions,
-  $hashtags
+  $hashtags,
+  $cashtags
 );
 
 var_dump($tweet->linkify());

--- a/src/Entity/Cashtag.php
+++ b/src/Entity/Cashtag.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Jedkirby\TweetEntityLinker\Entity;
+
+class Cashtag extends AbstractEntity
+{
+    /**
+     * @var string
+     */
+    const ENTITY_KEY = '$';
+
+    /**
+     * {@inhertdoc}.
+     */
+    public function getRequiredProperties()
+    {
+        return ['text'];
+    }
+
+    /**
+     * {@inhertdoc}.
+     */
+    public function getSearchText()
+    {
+        return self::ENTITY_KEY . $this->data['text'];
+    }
+
+    /**
+     * {@inhertdoc}.
+     */
+    public function getHtml()
+    {
+        return sprintf(
+            '%s<a href="https://twitter.com/search?q=%s" target="_blank">%s</a>',
+            self::ENTITY_KEY,
+            urlencode(self::ENTITY_KEY . $this->data['text']),
+            $this->data['text']
+        );
+    }
+}

--- a/src/Tweet.php
+++ b/src/Tweet.php
@@ -25,6 +25,11 @@ class Tweet
     private $hashtags = [];
 
     /**
+     * @var array
+     */
+    private $cashtags = [];
+
+    /**
      * @param string $text
      * @param array $urls
      * @param array $mentions
@@ -32,9 +37,9 @@ class Tweet
      *
      * @return Tweet
      */
-    public static function make($text, array $urls = [], array $mentions = [], array $hashtags = [])
+    public static function make($text, array $urls = [], array $mentions = [], array $hashtags = [], array $cashtags = [])
     {
-        return new self($text, $urls, $mentions, $hashtags);
+        return new self($text, $urls, $mentions, $hashtags, $cashtags);
     }
 
     /**
@@ -42,13 +47,15 @@ class Tweet
      * @param array $urls
      * @param array $mentions
      * @param array $hashtags
+     * @param array $cashtags
      */
-    private function __construct($text, array $urls = [], array $mentions = [], array $hashtags = [])
+    private function __construct($text, array $urls = [], array $mentions = [], array $hashtags = [], array $cashtags = [])
     {
         $this->text = $text;
         $this->urls = $urls;
         $this->mentions = $mentions;
         $this->hashtags = $hashtags;
+        $this->cashtags = $cashtags;
     }
 
     /**
@@ -59,6 +66,10 @@ class Tweet
     public function linkify()
     {
         $entities = [];
+
+        foreach($this->cashtags as $cashtag) {
+            $entities[] = new Entity\Cashtag($cashtag);
+        }
 
         foreach ($this->hashtags as $hashtag) {
             $entities[] = new Entity\Hashtag($hashtag);


### PR DESCRIPTION
This pull request adds support for cashtags (aka stock symbols).

Ignore my custom styles for links:

<img width="679" alt="Screen Shot 2022-05-13 at 11 30 42 AM" src="https://user-images.githubusercontent.com/64276359/168345467-57cb2a71-198c-4b35-978e-28024cde3008.png">

<img width="575" alt="Screen Shot 2022-05-13 at 11 30 51 AM" src="https://user-images.githubusercontent.com/64276359/168345469-0b191d20-0f31-4806-99d4-c733c13f1d1e.png">

